### PR TITLE
Add maven deployment info to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ the [HD5 2.8](http://www.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/HDF-JAVA-2.8/bi
 
 # Maven
 
-A maven release is hosted by the [Professorship for Modeling Spatial Mobility](https://www.bgu.tum.de/en/msm/start-page/) at TU Munich. You can access it by defining the following repository iny our .pom:
+A maven release is hosted by the [Professorship for Modeling Spatial Mobility](https://www.bgu.tum.de/en/msm/start-page/) at TU Munich. You can access it by defining the following repository in your .pom:
 ```
 <repositories>
   <repository>
@@ -41,7 +41,7 @@ A maven release is hosted by the [Professorship for Modeling Spatial Mobility](h
   </repository>
 </repositories>
 ```
-In the dependencies section of you. pom file add:
+In the dependencies section of your .pom file add:
 ```
 <dependency>
   <groupId>omx</groupId>

--- a/README.md
+++ b/README.md
@@ -22,4 +22,33 @@ The binary libraries in /lib/ are required to run the model, and must be present
 To build with the included omx.aml ant script, you need 
 the [HD5 2.8](http://www.hdfgroup.org/ftp/HDF5/releases/HDF-JAVA/HDF-JAVA-2.8/bin/) libraries.
 
+# Maven
+
+A maven release is hosted by the [Professorship for Modeling Spatial Mobility](https://www.bgu.tum.de/en/msm/start-page/) at TU Munich. You can access it by defining the following repository iny our .pom:
+```
+<repositories>
+  <repository>
+    <id>msmobility-msm</id>
+    <url>https://dl.cloudsmith.io/public/msmobility/msm/maven/</url>
+    <releases>
+      <enabled>true</enabled>
+      <updatePolicy>always</updatePolicy>
+    </releases>
+    <snapshots>
+      <enabled>true</enabled>
+      <updatePolicy>always</updatePolicy>
+    </snapshots>
+  </repository>
+</repositories>
+```
+In the dependencies section of you. pom file add:
+```
+<dependency>
+  <groupId>omx</groupId>
+  <artifactId>omx</artifactId>
+  <version>2</version>
+</dependency>
+```
+
+Please note that this does not include the native hdf5 libraries that you will need to setup independently. They can be found in the release/lib folder of this repository.
 


### PR DESCRIPTION
This PR adds info to the maven deployment of a stable java omx release at the cloudsmith repository of the msm research group at TUM.